### PR TITLE
Load & import required package janitor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,4 @@ LazyData: true
 RoxygenNote: 7.3.1
 Imports:
     dplyr (>= 1.0.0)
+    janitor


### PR DESCRIPTION
`councilverse::get_census_variables` requires the janitor pkg when reading it in councilverse.rmd